### PR TITLE
Add docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+---
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: ${{ matrix.platform }} ${{ matrix.python-version }}
+    runs-on: ${{ matrix.platform }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest]
+        python-version: [3.7]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup miniconda
+        uses: conda-incubator/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          channels: conda-forge,ome
+          environment-file: environment.yml
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run tests
+        shell: bash -l {0}
+        run: make

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,4 @@ RUN conda env create -f environment.yml -n z
 SHELL ["conda", "run", "-n", "z", "/bin/bash", "-c"]
 
 COPY . /src
-RUN pip install pyn5
 ENTRYPOINT ["conda", "run", "-n", "z", "make"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM continuumio/miniconda3
+
+WORKDIR /src
+COPY environment.yml /src/environment.yml
+RUN apt-get update -y && apt install -y freeglut3-dev
+RUN conda env create -f environment.yml -n z
+SHELL ["conda", "run", "-n", "z", "/bin/bash", "-c"]
+
+COPY . /src
+RUN pip install pyn5
+ENTRYPOINT ["conda", "run", "-n", "z", "make"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+test: data
+	pytest -v
+
 data/reference_image.png:
 	python generate_reference_image.py
 
@@ -21,6 +24,3 @@ zarr: data/reference_image.png
 data: n5java pyn5 z5py zarr
 
 .PHONY: test
-test: data
-	pytest -v
-

--- a/environment.yml
+++ b/environment.yml
@@ -1,32 +1,15 @@
-#name: z
 channels:
-  - defaults
-  - ome
   - conda-forge
-  - anaconda
+  - defaults
 dependencies:
   - openjdk
   - maven
   - make
   - z5py
   - python == 3.7.9
-  - pyside2
-  - napari
   - flake8
-  - ipython
-  - mypy
-  - omero-py
-  - opencv
   - pip
-  - py-opencv
   - pytest
-  - requests
-  - s3fs
-  - scikit-image
-  - scipy
-  - xarray
   - zarr >= 2.4.0
   - pip:
-      - pre-commit
-      - pytest-qt
       - pyn5

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,35 @@
+#name: z
+channels:
+  - defaults
+  - ome
+  - conda-forge
+  - anaconda
+dependencies:
+  - openjdk
+  - maven
+  - make
+  - z5py
+  - python == 3.7.9
+  - pyside2
+  - napari
+  - flake8
+  - ipython
+  - mypy
+  - omero-py
+  - opencv
+  - pip
+  - py-opencv
+  - pytest
+  - requests
+  - s3fs
+  - scikit-image
+  - scipy
+  - xarray
+  - zarr >= 2.4.0
+  - pip:
+      - pre-commit
+      - pytest-qt
+# python.app -- only install on OSX:
+# sys_platform environment marker doesn't work in environment.yml
+#
+#

--- a/environment.yml
+++ b/environment.yml
@@ -7,9 +7,9 @@ dependencies:
   - make
   - z5py
   - python == 3.7.9
-  - flake8
-  - pip
+  - scikit-image
   - pytest
   - zarr >= 2.4.0
+  - pip
   - pip:
       - pyn5

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,4 @@ dependencies:
   - pip:
       - pre-commit
       - pytest-qt
-# python.app -- only install on OSX:
-# sys_platform environment marker doesn't work in environment.yml
-#
-#
+      - pyn5


### PR DESCRIPTION
I recently ran into an issue opening n5 from zarr. I figured this repo was a good place to start to figure out what's going on. I'll see if I can make a change that makes that test fail. In the meantime, this is the setup I used to build locally. Note that there are a few failures:

```
  /opt/conda/envs/z/lib/python3.7/site-packages/pyn5/file_group.py:228: UserWarning: Expected N5 version '2.0.2', got 2.1.3; trying to open anyway
...
FAILED test/test_read_all.py::test_correct_read[read z5py zarr using zarr, gzip] - OSError: Not a gzipped file (b'x^')
FAILED test/test_read_all.py::test_correct_read[read zarr N5 using z5py, gzip] - RuntimeError: Exception during zlib decompression: ...
FAILED test/test_read_all.py::test_correct_read[read zarr N5 using z5py, raw] - assert False
```